### PR TITLE
Updated nrx script as nrx.py was replaced with  shell script

### DIFF
--- a/4_run_nrx.sh
+++ b/4_run_nrx.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 source ./venv/bin/activate
-python3 ./nrx/nrx.py -c ./nrx.conf -o clab -D ./
+python3 ./nrx/nrx -c ./nrx.conf -o clab -D ./
 


### PR DESCRIPTION
Step 4 fails because nrx changed nrx.py to a shell script called [nrx](https://github.com/netreplica/nrx/blob/749a295665d9782f7e93841698a0d1f86df6febd/nrx) in commit https://github.com/netreplica/nrx/commit/7ac726015b1bf034b236bf9c23cb21065f3993a8

