### PR TITLE
Pin Netbox docker containers to v3.7.8

### DIFF
--- a/netbox/docker-compose.override.yml
+++ b/netbox/docker-compose.override.yml
@@ -1,4 +1,3 @@
-version: '3.7'
 services:
   netbox:
     ports:

--- a/netbox/docker-compose.yml
+++ b/netbox/docker-compose.yml
@@ -1,6 +1,4 @@
 ---
-version: '3.7'
-
 volumes:
   netbox-media-files:
   netbox-postgres-data:
@@ -14,7 +12,7 @@ services:
   # Netbox
   # -------
   netbox: &netbox
-    image: ghcr.io/netbox-community/netbox:latest
+    image: ghcr.io/netbox-community/netbox:v3.7.8
     depends_on:
     - postgres
     - redis


### PR DESCRIPTION
Due to Netbox 4.0 having an API breaking change with device_role, this commit pins the Netbox version to the last 3.x release. This is a temporary stabilising fix while PR https://github.com/netreplica/nrx/pull/123 is in review to make NRX compatible with Netbox 4.0.