### PR TITLE
Un-pinning from Netbox v3.x - NRX now supports Netbox 4.x API

### DIFF
--- a/netbox/docker-compose.yml
+++ b/netbox/docker-compose.yml
@@ -12,7 +12,7 @@ services:
   # Netbox
   # -------
   netbox: &netbox
-    image: ghcr.io/netbox-community/netbox:v3.7.8
+    image: ghcr.io/netbox-community/netbox:latest
     depends_on:
     - postgres
     - redis
@@ -20,7 +20,7 @@ services:
     env_file: netbox.env
     user: 'unit:root'
     healthcheck:
-      start_period: 90s
+      start_period: 120s
       timeout: 3s
       interval: 15s
       test: "curl -f http://localhost:8080/api/ || exit 1"


### PR DESCRIPTION
Netreplica NRX has now been updated to support the Netbox 4.x API changes. I've also bumped the start-up time as there are more Django migrations between the 3.x and 4.x database schemas. I'm keeping the database snapshot in 3.x format in the repo if users wanted to use >=v3.7.8 Netbox.