### PR TITLE
Fixing the health-check endpoint for Netbox v4.x

### DIFF
--- a/netbox/docker-compose.yml
+++ b/netbox/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       start_period: 120s
       timeout: 3s
       interval: 15s
-      test: "curl -f http://localhost:8080/api/ || exit 1"
+      test: "curl -f http://localhost:8080/login/ || exit 1"
     volumes:
     - netbox-media-files:/opt/netbox/netbox/media:z,rw
     - netbox-reports-files:/opt/netbox/netbox/reports:z,rw


### PR DESCRIPTION
Fixing the health-check endpoint for Netbox v4.x to point to the login screen. v4.x ch…anged the /api/ endpoint to need auth to return HTTP 2xx.